### PR TITLE
Publish Auto Regression post

### DIFF
--- a/content/posts/auto-regression/auto_regression.ipynb
+++ b/content/posts/auto-regression/auto_regression.ipynb
@@ -11,7 +11,7 @@
     "date = \"2026-07-03\"\n",
     "description = \"An overview of how Auto Regression models work\"\n",
     "math = true\n",
-    "draft = true\n",
+    "draft = false\n",
     "tags = [\n",
     "    \"ml\",\n",
     "    \"data science\",\n",

--- a/content/posts/auto-regression/index.md
+++ b/content/posts/auto-regression/index.md
@@ -4,7 +4,7 @@ title = "Auto Regression"
 date = "2026-07-03"
 description = "An overview of how Auto Regression models work"
 math = true
-draft = true
+draft = false
 tags = [
     "ml",
     "data science",


### PR DESCRIPTION
## Summary
- Flips `draft = false` on the Auto Regression post so it's included in the production build (CI runs plain `hugo`, no `-D`, so drafts are excluded from the live site - this is why it wasn't showing up after the last merge).