### PR TITLE
Fix broken deploy: bump CI Hugo version to 0.124.1

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -31,7 +31,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.120.4
+      HUGO_VERSION: 0.124.1
     steps:
       - name: Install Hugo CLI
         run: |


### PR DESCRIPTION
## Summary
- The `repo-hygiene` PR pinned `themes/hugo-coder` to a commit that calls `hugo.IsMultilingual`, a template function not available in Hugo 0.120.4 (the version pinned in `.github/workflows/hugo.yml`). This broke the "Deploy Hugo site to Pages" workflow on every push to `main` since, starting with the repo-hygiene merge itself.
- Bumps `HUGO_VERSION` from `0.120.4` to `0.124.1`, matching the Hugo version already installed locally (which builds this exact theme commit without issue).

## Test plan
- [x] Confirmed the Hugo release asset exists for 0.124.1 (`hugo_extended_0.124.1_linux-amd64.deb`)
- [x] Ran a production-style local build (`HUGO_ENVIRONMENT=production HUGO_ENV=production hugo --minify --baseURL "https://sailingdatalakes.com/"`) with Hugo 0.124.1 — builds cleanly, no compatibility warning, 59 pages rendered including the gradient-descent post with its new Algorithm section