### PR TITLE
Add final swing metrics to the conclusion

### DIFF
--- a/content/projects/home-run-ballistics/Home_Run_Ballistics.ipynb
+++ b/content/projects/home-run-ballistics/Home_Run_Ballistics.ipynb
@@ -80,10 +80,10 @@
    "id": "88fb1752",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T23:59:29.097669Z",
-     "iopub.status.busy": "2026-07-04T23:59:29.097378Z",
-     "iopub.status.idle": "2026-07-04T23:59:30.339109Z",
-     "shell.execute_reply": "2026-07-04T23:59:30.337937Z"
+     "iopub.execute_input": "2026-07-05T00:09:46.623964Z",
+     "iopub.status.busy": "2026-07-05T00:09:46.623654Z",
+     "iopub.status.idle": "2026-07-05T00:09:47.373646Z",
+     "shell.execute_reply": "2026-07-05T00:09:47.372760Z"
     }
    },
    "outputs": [],
@@ -126,10 +126,10 @@
    "id": "fcac7a91",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T23:59:30.343865Z",
-     "iopub.status.busy": "2026-07-04T23:59:30.343218Z",
-     "iopub.status.idle": "2026-07-04T23:59:30.351122Z",
-     "shell.execute_reply": "2026-07-04T23:59:30.350428Z"
+     "iopub.execute_input": "2026-07-05T00:09:47.377463Z",
+     "iopub.status.busy": "2026-07-05T00:09:47.377063Z",
+     "iopub.status.idle": "2026-07-05T00:09:47.384431Z",
+     "shell.execute_reply": "2026-07-05T00:09:47.383848Z"
     }
    },
    "outputs": [],
@@ -191,10 +191,10 @@
    "id": "2a96d90d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T23:59:30.354660Z",
-     "iopub.status.busy": "2026-07-04T23:59:30.354358Z",
-     "iopub.status.idle": "2026-07-04T23:59:30.508510Z",
-     "shell.execute_reply": "2026-07-04T23:59:30.507885Z"
+     "iopub.execute_input": "2026-07-05T00:09:47.387506Z",
+     "iopub.status.busy": "2026-07-05T00:09:47.387264Z",
+     "iopub.status.idle": "2026-07-05T00:09:47.514389Z",
+     "shell.execute_reply": "2026-07-05T00:09:47.513674Z"
     }
    },
    "outputs": [
@@ -262,10 +262,10 @@
    "id": "f4840f9b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T23:59:30.511164Z",
-     "iopub.status.busy": "2026-07-04T23:59:30.510965Z",
-     "iopub.status.idle": "2026-07-04T23:59:30.514937Z",
-     "shell.execute_reply": "2026-07-04T23:59:30.514394Z"
+     "iopub.execute_input": "2026-07-05T00:09:47.517758Z",
+     "iopub.status.busy": "2026-07-05T00:09:47.517428Z",
+     "iopub.status.idle": "2026-07-05T00:09:47.521146Z",
+     "shell.execute_reply": "2026-07-05T00:09:47.520604Z"
     }
    },
    "outputs": [],
@@ -310,10 +310,10 @@
    "id": "09391b9c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T23:59:30.517573Z",
-     "iopub.status.busy": "2026-07-04T23:59:30.517380Z",
-     "iopub.status.idle": "2026-07-04T23:59:30.522271Z",
-     "shell.execute_reply": "2026-07-04T23:59:30.521754Z"
+     "iopub.execute_input": "2026-07-05T00:09:47.523745Z",
+     "iopub.status.busy": "2026-07-05T00:09:47.523558Z",
+     "iopub.status.idle": "2026-07-05T00:09:47.527872Z",
+     "shell.execute_reply": "2026-07-05T00:09:47.527376Z"
     }
    },
    "outputs": [],
@@ -353,10 +353,10 @@
    "id": "0d062f45",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T23:59:30.524808Z",
-     "iopub.status.busy": "2026-07-04T23:59:30.524611Z",
-     "iopub.status.idle": "2026-07-04T23:59:30.604655Z",
-     "shell.execute_reply": "2026-07-04T23:59:30.603994Z"
+     "iopub.execute_input": "2026-07-05T00:09:47.531284Z",
+     "iopub.status.busy": "2026-07-05T00:09:47.530898Z",
+     "iopub.status.idle": "2026-07-05T00:09:47.610648Z",
+     "shell.execute_reply": "2026-07-05T00:09:47.610171Z"
     }
    },
    "outputs": [
@@ -400,10 +400,10 @@
    "id": "54b98254",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T23:59:30.607152Z",
-     "iopub.status.busy": "2026-07-04T23:59:30.606959Z",
-     "iopub.status.idle": "2026-07-04T23:59:30.801865Z",
-     "shell.execute_reply": "2026-07-04T23:59:30.801304Z"
+     "iopub.execute_input": "2026-07-05T00:09:47.613335Z",
+     "iopub.status.busy": "2026-07-05T00:09:47.613087Z",
+     "iopub.status.idle": "2026-07-05T00:09:47.810998Z",
+     "shell.execute_reply": "2026-07-05T00:09:47.810524Z"
     }
    },
    "outputs": [
@@ -488,10 +488,10 @@
    "id": "202ee349",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T23:59:30.804588Z",
-     "iopub.status.busy": "2026-07-04T23:59:30.804390Z",
-     "iopub.status.idle": "2026-07-04T23:59:32.622296Z",
-     "shell.execute_reply": "2026-07-04T23:59:32.621813Z"
+     "iopub.execute_input": "2026-07-05T00:09:47.813624Z",
+     "iopub.status.busy": "2026-07-05T00:09:47.813395Z",
+     "iopub.status.idle": "2026-07-05T00:09:49.717503Z",
+     "shell.execute_reply": "2026-07-05T00:09:49.717045Z"
     }
    },
    "outputs": [
@@ -588,10 +588,10 @@
    "id": "6b1e59fe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-04T23:59:32.625290Z",
-     "iopub.status.busy": "2026-07-04T23:59:32.625013Z",
-     "iopub.status.idle": "2026-07-04T23:59:32.958092Z",
-     "shell.execute_reply": "2026-07-04T23:59:32.957484Z"
+     "iopub.execute_input": "2026-07-05T00:09:49.720374Z",
+     "iopub.status.busy": "2026-07-05T00:09:49.720147Z",
+     "iopub.status.idle": "2026-07-05T00:09:50.074872Z",
+     "shell.execute_reply": "2026-07-05T00:09:50.073802Z"
     }
    },
    "outputs": [
@@ -717,7 +717,13 @@
     "- **Idealized taper.** The bat is modeled as a smooth cone with a fixed handle-to-barrel taper ratio, not the actual measured profile of a TX73, and \"balance factor\" is a rough stand-in for a real moment-of-inertia measurement.\n",
     "- **Crosswind ignored.** It affects where the ball lands sideways, not how far it carries or how long it hangs, so leaving it out doesn't bias the distance/time solve - but it does mean this model has nothing to say about how far off the labeled hit direction the ball actually drifted.\n",
     "\n",
-    "None of that makes this a replacement for a TrackMan. It does turn \"I think it went about 390-400 feet and hung around four and a quarter seconds\" into a genuinely informative estimate - which is exactly the kind of thing worth having for a beer-league home run nobody was tracking with radar."
+    "None of that makes this a replacement for a TrackMan. It does turn \"I think it went about 390-400 feet and hung around four and a quarter seconds\" into a genuinely informative estimate, and for this particular swing that estimate comes out to:\n",
+    "\n",
+    "- **Exit velocity:** 96.0-98.5 mph\n",
+    "- **Launch angle:** 22.7-23.6°\n",
+    "- **Swing speed:** 69.1-71.2 mph\n",
+    "\n",
+    "A real, hard-hit line-drive home run - exactly the kind of thing worth having for a beer-league home run nobody was tracking with radar."
    ]
   }
  ],

--- a/content/projects/home-run-ballistics/index.md
+++ b/content/projects/home-run-ballistics/index.md
@@ -498,4 +498,10 @@ It's also worth being honest about where this model would break down or mislead:
 - **Idealized taper.** The bat is modeled as a smooth cone with a fixed handle-to-barrel taper ratio, not the actual measured profile of a TX73, and "balance factor" is a rough stand-in for a real moment-of-inertia measurement.
 - **Crosswind ignored.** It affects where the ball lands sideways, not how far it carries or how long it hangs, so leaving it out doesn't bias the distance/time solve - but it does mean this model has nothing to say about how far off the labeled hit direction the ball actually drifted.
 
-None of that makes this a replacement for a TrackMan. It does turn "I think it went about 390-400 feet and hung around four and a quarter seconds" into a genuinely informative estimate - which is exactly the kind of thing worth having for a beer-league home run nobody was tracking with radar.
+None of that makes this a replacement for a TrackMan. It does turn "I think it went about 390-400 feet and hung around four and a quarter seconds" into a genuinely informative estimate, and for this particular swing that estimate comes out to:
+
+- **Exit velocity:** 96.0-98.5 mph
+- **Launch angle:** 22.7-23.6°
+- **Swing speed:** 69.1-71.2 mph
+
+A real, hard-hit line-drive home run - exactly the kind of thing worth having for a beer-league home run nobody was tracking with radar.


### PR DESCRIPTION
## Summary
- The Conclusion previously only described the modeling approach and caveats without restating the actual computed results, which led to a reviewer mistakenly thinking the bat-collision/swing-speed stage of the project wasn't finished.
- Added the final recovered numbers (exit velocity, launch angle, swing speed) directly to the closing paragraph so the bottom line is visible without reading the full Example section.

## Test plan
- [x] Notebook re-executes end-to-end with no errors
- [x] `index.md` conclusion now states exit velocity (96.0-98.5 mph), launch angle (22.7-23.6°), and swing speed (69.1-71.2 mph)