### PR TITLE
Add baseball to hobbies on About page

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -23,7 +23,7 @@ my own understanding of these algorithms, and it's grown into something I
 hope is useful to others working in the space too.
 
 Outside of work, I spend most of my time with my family. We're big
-on hobbies, such as sailing, kayaking, cooking, fishing, swimming,
+on hobbies, such as sailing, baseball, kayaking, cooking, fishing, swimming,
 and shark tooth hunting! When I can, I'll try and include these activities
 in my projects.
 


### PR DESCRIPTION
Small copy fix — baseball was missing from the hobbies list (the site already has two baseball-physics projects).