### PR TITLE
Add RSS link to main nav

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -184,6 +184,13 @@ name = "Projects"
 weight = 3
 url = "projects/"
 
+[[languages.en.menu.main]]
+name = "RSS"
+weight = 4
+url = "index.xml"
+rel = "alternate"
+type = "application/rss+xml"
+
 #[[languages.en.menu.main]]
 #name = "Resume"
 #weight = 3


### PR DESCRIPTION
## Summary
- Adds "RSS" to the main nav menu, linking to the existing `index.xml` feed
- Feed generation and the social-icon RSS link already existed (`hugo.toml:161-167`); this just makes it discoverable as a real nav item

## Test plan
- [x] `hugo --minify` build succeeds
- [x] `index.xml` renders a valid RSS feed with post entries
- [x] Nav bar renders "About | Blog | Projects | RSS" linking to `/index.xml`