### PR TITLE
Enable GoatCounter analytics

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -60,8 +60,8 @@ customRemoteJS = []
 # fileDownloadsTracking = true
 
 # If you want to use goatcounter(https://goatcounter.com) for analytics, add this section
-# [params.goatCounter]
-# code = "code"
+[params.goatCounter]
+code = "sailingdatalakes"
 
 # If you want to use Cloudflare Web Analytics(https://cloudflare.com) for analytics, add this section
 # [params.cloudflare]


### PR DESCRIPTION
## Summary
- Enables the theme's built-in GoatCounter analytics param, pointing at `sailingdatalakes.goatcounter.com`
- No custom code — just wiring the site code into the theme's existing `[params.goatCounter]` support

## Test plan
- [x] `hugo --minify` build succeeds
- [x] Rendered `<head>` includes `<script data-goatcounter=https://sailingdatalakes.goatcounter.com/count async src=//gc.zgo.at/count.js></script>`